### PR TITLE
Added support for ssl configuration

### DIFF
--- a/default.toml
+++ b/default.toml
@@ -4,6 +4,8 @@ log_level = "info"
 influxdb_host = "127.0.0.1"
 influxdb_port = "8086"
 influxdb_database = "pihole"
+influxdb_ssl = "False"
+influxdb_verify_ssl = "True"
 
 request_timeout = 10
 reporting_interval = 30

--- a/piholeinflux.py
+++ b/piholeinflux.py
@@ -52,6 +52,8 @@ class Daemon(object):
             username=settings.get("INFLUXDB_USERNAME"),
             password=settings.get("INFLUXDB_PASSWORD"),
             database=settings.INFLUXDB_DATABASE,
+            ssl=settings.as_bool("INFLUXDB_SSL"),
+            verify_ssl=settings.as_bool("INFLUXDB_VERIFY_SSL"),
         )
         self.single_run = single_run
 


### PR DESCRIPTION
Added `influx_ssl` and `influx_verify_ssl` configuration settings that control the corresponding values passed to `InfluxDB.InfluxDBClient` constructor (see: [InfluxDBClient](https://influxdb-python.readthedocs.io/en/latest/api-documentation.html#influxdbclient)).

Values set in `default.toml` are those required to work without SSL, as originally coded.