### PR TITLE
remove absolute path from `ln` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cp user.toml.example user.toml
 vi user.toml
 ```
 
-Before starting the daemon for the first time, symlink the systemd service into place, reload, and enable the service.
+Before starting the daemon for the first time, symlink the systemd service into place, reload, and enable the service. Note that if you are using a user that isn't `pi`, you must edit piholeinflux.service and change `ExecStart` to run the correct path.
 
 ```bash
 sudo ln -s piholeinflux.service /etc/systemd/system/

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ vi user.toml
 Before starting the daemon for the first time, symlink the systemd service into place, reload, and enable the service.
 
 ```bash
-sudo ln -s /home/pi/pi-hole-influx/piholeinflux.service /etc/systemd/system/
+sudo ln -s piholeinflux.service /etc/systemd/system/
 sudo systemctl --system daemon-reload
 sudo systemctl enable piholeinflux.service
 ```

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ cp user.toml.example user.toml
 vi user.toml
 ```
 
-Before starting the daemon for the first time, symlink the systemd service into place, reload, and enable the service. Note that if you are using a user that isn't `pi`, you must edit piholeinflux.service and change `ExecStart` to run the correct path.
+Before starting the daemon for the first time, symlink the systemd service into place, reload, and enable the service. Note that if you are using a user that isn't `pi`, you must edit piholeinflux.service and change `ExecStart` to run the correct path. You must also change `User` to the correct user.
 
 ```bash
 sudo ln -s piholeinflux.service /etc/systemd/system/


### PR DESCRIPTION
You might not agree with this, but I think that the `ln` command should not use an absolute path, since if a different user was used for the cloning of the repo, the command fails silently and you won't notice until you try to enable the service.